### PR TITLE
Used absolute links since the ~ and relative links weren't working for this layout.

### DIFF
--- a/azureps-cmdlets-docs/index.md
+++ b/azureps-cmdlets-docs/index.md
@@ -12,18 +12,18 @@ ms.manager: carolz
 
 Azure PowerShell cmdlets provide support for the following Azure services:
 
-[Azure Resource Manager](https://docs.microsoft.com/en-us/powershell/resourcemanager/)
+[Azure Resource Manager](~/powershell/resourcemanager/)
 
 Azure Resource Manager enables you to work with the resources in your solution as a group.
 You can deploy, update, or delete all the resources for your solution in a single, coordinated operation.
 
 
-[Azure Service Management](https://docs.microsoft.com/en-us/powershell/servicemanagement/)
+[Azure Service Management](~/powershell/servicemanagement/)
 
 Azure Service Management helps you manage your deployments, hosted services, and storage accounts.
 
 
-[Azure Storage](https://docs.microsoft.com/en-us/powershell/storage/)
+[Azure Storage](~/powershell/storage/)
 
 Azure Storage is the cloud storage solution for modern applications that rely on durability, availability, and scalability to meet your needs.
 Storage supports Blob storage, File storage, Queue storage, and Table storage.


### PR DESCRIPTION
We should move these to relative links when we figure out how to make it work. I made this fix solely to address a break.
--
i have a doc (MD file) in the azure-docs-powershell repo, in a directory titled /azure-ps-docs.
below it, as subdirectories, i have three folders: /azure-ps-docs/storage, /azure-ps-docs/resourcemanager, and /azure-ps-docs/servicemanagement. i could not figure how, with our URL mapping scheme, to create a hyperlink from the index file in /azure-ps-docs to those subdirectories and have URLs that did NOT have "/azure-ps-docs" in them.
