### PR TITLE
Update create-azure-service-principal-azureps.md

### DIFF
--- a/azureps-cmdlets-docs/ResourceManager/docs-conceptual/create-azure-service-principal-azureps.md
+++ b/azureps-cmdlets-docs/ResourceManager/docs-conceptual/create-azure-service-principal-azureps.md
@@ -73,6 +73,7 @@ ReplyUrls               : {}
 The `New-AzureRmADServicePrincipal` cmdlet is used to create the service principal.
 
 ```powershell
+Add-Type -Assembly System.Web
 $password = [System.Web.Security.Membership]::GeneratePassword(16,3)
 New-AzureRmADServicePrincipal -ApplicationId 00c01aaa-1603-49fc-b6df-b78c4e5138b4 -Password $password
 ```


### PR DESCRIPTION
Using the GeneratePassword method means you need to have the System.Web.Membership available - this namespace is not loaded by default. To load it, you use Add-Type -Assembly Systgem/Web. The change to this page reflects that.

NB: If you do not use Add-type, you get this output:

PS C:\foo> [System.Web.Security.Membership]::GeneratePassword(16,3)
Unable to find type [System.Web.Security.Membership].
At line:1 char:1
+ [System.Web.Security.Membership]::GeneratePassword(16,3)
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Web.Security.Membership:TypeName) [], RuntimeException
    + FullyQualifiedErrorId : TypeNotFound