### PR TITLE
The sample for multiple emails wrongly has quotes

### DIFF
--- a/azureps-cmdlets-docs/ResourceManager/AzureRM.Insights/v1.0.12/New-AzureRmAlertRuleEmail.md
+++ b/azureps-cmdlets-docs/ResourceManager/AzureRM.Insights/v1.0.12/New-AzureRmAlertRuleEmail.md
@@ -30,7 +30,7 @@ This command creates an alert rule email action to send for its service owners w
 
 ### Example 2: Create an alert rule email action for non-service owners
 ```
-PS C:\>New-AzureRmAlertRuleEmail -CustomEmails "pattif@contoso.com, davidchew@contoso.net"
+PS C:\>New-AzureRmAlertRuleEmail -CustomEmails pattif@contoso.com, davidchew@contoso.net
 ```
 
 This command creates an alert rule email action for the specified email addresses, but not for the service owners.

--- a/azureps-cmdlets-docs/ResourceManager/AzureRM.Insights/v3.3.1/New-AzureRmAlertRuleEmail.md
+++ b/azureps-cmdlets-docs/ResourceManager/AzureRM.Insights/v3.3.1/New-AzureRmAlertRuleEmail.md
@@ -33,7 +33,7 @@ This command creates an alert rule email action to send for its service owners w
 
 ### Example 2: Create an alert rule email action for non-service owners
 ```
-PS C:\>New-AzureRmAlertRuleEmail -CustomEmails "pattif@contoso.com, davidchew@contoso.net"
+PS C:\>New-AzureRmAlertRuleEmail -CustomEmails pattif@contoso.com, davidchew@contoso.net
 ```
 
 This command creates an alert rule email action for the specified email addresses, but not for the service owners.


### PR DESCRIPTION
The CustomEmails parameter is an String[] and does not work well if we use "" on it.
Add-AzureRmMetricAlertRule would fail with: Add-AzureRmMetricAlertRule : The email is invalid.
If we include more than one email within quotes because the format does not match for one email.