### PR TITLE
Update Get-AzureRmImage.md

### DIFF
--- a/azurermps-5.0.0/AzureRM.Compute/Get-AzureRmImage.md
+++ b/azurermps-5.0.0/AzureRM.Compute/Get-AzureRmImage.md
@@ -48,7 +48,9 @@ This command gets the properties of all images under the subscription.
 ## PARAMETERS
 
 ### -DefaultProfile
-The credentials, account, tenant, and subscription used for communication with azure.```yaml
+The credentials, account, tenant, and subscription used for communication with Azure.
+
+```yaml
 Type: Microsoft.Azure.Commands.Common.Authentication.Abstractions.IAzureContextContainer
 Parameter Sets: (All)
 Aliases: AzureRmContext, AzureCredential


### PR DESCRIPTION
Fix a missing line return that caused error in rendering this page.
Changed a spelling - 'azure' to 'Azure'.