### PR TITLE
Add a command required for Login-AzureRmAccount

### DIFF
--- a/docs-conceptual/azurermps-5.1.1/install-azurermps-maclinux.md
+++ b/docs-conceptual/azurermps-5.1.1/install-azurermps-maclinux.md
@@ -57,6 +57,7 @@ loaded using the `Import-Module` cmdlet, as follows:
 
 ```powershell
 Import-Module AzureRM.Netcore
+Import-Module AzureRM.Profile.Netcore
 ```
 
 After the import completes, you can test your newly installed and module by attempting to sign into


### PR DESCRIPTION
When I followed this instruction, I saw the following error: 

```
Login-AzureRmAccount : The term 'Add-AzureRmAccount' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At /var/folders/_l/9yzlbg193032kq9tqz206j4j_d7vyd/T/tempCodeRunnerFile.ps1:4 char:1
+ Login-AzureRmAccount
+ ~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (Add-AzureRmAccount:String) [], CommandNotFoundException
+ FullyQualifiedErrorId : CommandNotFoundException
```

I found the cmdlet `Add-AzureRmAccount` is provided by `AzureRM.Profile.Netcore` and  the above error is resolved by loading the module: `Import-Module AzureRM.Profile.Netcore`.