### PR TITLE
Removing RMSProtection from TOC

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -266,8 +266,6 @@
                     "AADRM/**/*.yml",
                     "AzureInformationProtection/**/*.md",
                     "AzureInformationProtection/**/*.yml",
-                    "RMSProtection/**/*.md",
-                    "RMSProtection/**/*.yml",
                     "AzureAD/**/*.md",
                     "AzureAD/**/*.yml",
                     "ElasticDatabaseJobs/**/*.md",


### PR DESCRIPTION
The RMSProtecttion node and files have been removed from https://github.com/Azure/azure-docs-powershell-aip/tree/master/Azure%20Information%20Protection and redircts are in place. Removing them from TOC as well.