### PR TITLE
Remove bad advice on module loading

### DIFF
--- a/docs-conceptual/azurermps-5.5.0/install-azurerm-ps.md
+++ b/docs-conceptual/azurermps-5.5.0/install-azurerm-ps.md
@@ -87,15 +87,6 @@ If you have a previous version of Azure PowerShell installed you may receive an 
 this issue, see the [Updating to a new version of Azure PowerShell](#update-azps) section of this
 article.
 
-## Step 3: Load the AzureRM module
-Once the module is installed, you need to load the module into your PowerShell session. You should
-do this in a normal (non-elevated) PowerShell session. Modules are loaded using the `Import-Module`
-cmdlet, as follows:
-
-```powershell
-Import-Module -Name AzureRM
-```
-
 ## Next Steps
 
 For more information about using Azure PowerShell, see the following articles:


### PR DESCRIPTION
AzureRM is a roll-up module that contaisn 50+ dependent modules.  There is *no need* to load this module in the customer's session.  PowerShell will discover the modules as cmdlets are used.  Adding this step takes an additional minute and a half that si totally unnecessary, and loads 50 modules into memory.  Please remove this as a recommended step.