### PR TITLE
Fix malformed regions link

### DIFF
--- a/azuresmps-4.0.0/Azure/Add-AzureTrafficManagerEndpoint.md
+++ b/azuresmps-4.0.0/Azure/Add-AzureTrafficManagerEndpoint.md
@@ -71,7 +71,7 @@ Specifies the location of the endpoint the cmdlet adds.
 This must be an Azure location.
 
 This parameter must contain a value for endpoints of the type "Any" or of type "TrafficManager" in a profile that has the load balancing method set to "Performance".
-The possible values are the Azure region names, as listed at  http://azure.microsoft.com/regions/http://azure.microsoft.com/regions/.
+The possible values are the Azure region names, as listed at http://azure.microsoft.com/regions/.
 
 ```yaml
 Type: String


### PR DESCRIPTION
The current regions link points to a malformed url. Fixed the url to point to the intended destination.