### PR TITLE
Fix reading of public key

### DIFF
--- a/docs-conceptual/azurermps-6.1.0/get-started-azureps.md
+++ b/docs-conceptual/azurermps-6.1.0/get-started-azureps.md
@@ -243,7 +243,7 @@ $vmConfig = New-AzureRmVMConfig -VMName $vmName -VMSize Standard_D1 |
   Add-AzureRmVMNetworkInterface -Id $nic.Id
 
 # Configure SSH Keys
-$sshPublicKey = Get-Content "$env:USERPROFILE\.ssh\id_rsa.pub"
+$sshPublicKey = Get-Content -Raw "$env:USERPROFILE\.ssh\id_rsa.pub"
 Add-AzureRmVMSshPublicKey -VM $vmConfig -KeyData $sshPublicKey -Path "/home/azureuser/.ssh/authorized_keys"
 ```
 


### PR DESCRIPTION
At least on my machine `Get-Content` without the `-Raw` flag returns an array of lines instead of the required full String.