### PR TITLE
Fix wrong parameter name in the example

### DIFF
--- a/azurestackps-1.3.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
+++ b/azurestackps-1.3.0/Azs.Azurebridge.Admin/Invoke-AzsAzureBridgeProductDownload.md
@@ -31,7 +31,7 @@ Downloads a product from azure marketplace.
 
 ### EXAMPLE 1
 ```
-Invoke-AzsAzureBridgeProductDownload -ActivationName 'myActivation' -ProductName 'microsoft.docker-arm.1.1.0' -ResourceGroupName 'activationRG'
+Invoke-AzsAzureBridgeProductDownload -ActivationName 'myActivation' -Name 'microsoft.docker-arm.1.1.0' -ResourceGroupName 'activationRG'
 ```
 
 Download a product from Azure Marketplace


### PR DESCRIPTION
ProductName is not a valid parameter so if you run the example 1 it returns:

```powershell
Invoke-AzsAzureBridgeProductDownload : A parameter cannot be found that matches parameter name 'ProductName'.
At line:1 char:78
+ ... Download -ActivationName $ActivationDetails.Name -ProductName 'micros ...
+                                                      ~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Invoke-AzsAzureBridgeProductDownload], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Invoke-AzsAzureBridgeProductDownload
```