### PR TITLE
Add validateset values to add azsplantooffer cmdlet

### DIFF
--- a/azurestackps-1.3.0/Azs.Subscriptions.Admin/Add-AzsPlanToOffer.md
+++ b/azurestackps-1.3.0/Azs.Subscriptions.Admin/Add-AzsPlanToOffer.md
@@ -81,6 +81,7 @@ Type of the plan link.
 Type: String
 Parameter Sets: (All)
 Aliases:
+Accepted values: None, Base, Addon
 
 Required: False
 Position: 4

--- a/azurestackps-1.3.0/Azs.Subscriptions.Admin/Add-AzsPlanToOffer.md
+++ b/azurestackps-1.3.0/Azs.Subscriptions.Admin/Add-AzsPlanToOffer.md
@@ -24,7 +24,7 @@ Links a plan to an offer.
 
 ### EXAMPLE 1
 ```
-Add-AzsPlanToOffer -PlanLinkType Addon -Offer offer1 -PlanName plan1 -ResourceGroupName rg1 -MaxAcquisitionCount 2
+Add-AzsPlanToOffer -PlanLinkType Addon -OfferName offer1 -PlanName plan1 -ResourceGroupName rg1 -MaxAcquisitionCount 2
 ```
 
 ## PARAMETERS


### PR DESCRIPTION
I was having a hard time finding out what are the accepted values for PlanLinkType parameter so I am adding them in now as based on the Swagger code and the documentation: https://docs.microsoft.com/en-us/rest/api/azurestack/offers/link#planlinktype

Also fixing Offer parameter in the example to match actual parameter which is OfferName.