### PR TITLE
Update configuration 

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,6 +1,5 @@
 {
   "build_entry_point": "docs",
-  "need_generate_pdf": true,
   "need_preview_pull_request": true,
   "docsets_to_publish": [
     {

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1,11 +1,6 @@
 {
   "redirections": [
     {
-      "source_path": "docs-conceptual/index.md",
-      "redirect_url": "/powershell/azure/overview",
-      "redirect_document_id": false
-    },
-    {
       "source_path": "azureipps/azure/aip/index.md",
       "redirect_url": "/powershell/azure/aip/overview",
       "redirect_document_id": false


### PR DESCRIPTION
1. Update the publishingsetting since we are now support the PDF like this, configuration  
`"branch_target_mapping": {
    "live": [
      "Publish",
      "Pdf"
    ]}`

original "need_generate_pdf": true is not valid any more. Remove it.

2. Remove the direction rule for docs-conceptual/index.md in redirection since this md already defined redirection rule.

@jmazzotta @Banani-Rath could you please review this change and merge this PR? 