### PR TITLE
Fix Select-AzureRmSubscription incorrect parameter

### DIFF
--- a/docs-conceptual/azurermps-6.6.0/manage-subscriptions-azureps.md
+++ b/docs-conceptual/azurermps-6.6.0/manage-subscriptions-azureps.md
@@ -47,7 +47,7 @@ PowerShell to execute commands against a particular subscription.
 2. Set the default.
 
     ```azurepowershell-interactive
-    Select-AzureRmSubscription -SubscriptionName "My Demos"
+    Select-AzureRmSubscription -Subscription "My Demos"
     ```
 
 3. Verify the change by running the `Get-AzureRmContext` cmdlet.


### PR DESCRIPTION
Fixed the incorrect parameter syntax for `Select-AzureRmSubscription` alias of `Set-AzureRmContext` reported on #682.