### PR TITLE
Add odata filter example get azshealth

### DIFF
--- a/azurestackps-1.3.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
+++ b/azurestackps-1.3.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
@@ -47,6 +47,15 @@ Get-AzsAlert | Where State -EQ 'active' | select FaultTypeId, Title
 
 Get all active alerts and display their fault and title.
 
+### EXAMPLE 3
+```
+Get-AzsAlert -Filter "Properties/State eq 'Active'"
+```
+
+Get all active alerts using much more efficient OData filter than getting all alerts from and filtering from example above.
+
+Note: This is case sensitive so properties/state for instance will not work
+
 ## PARAMETERS
 
 ### -Name

--- a/azurestackps-1.3.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
+++ b/azurestackps-1.3.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
@@ -52,7 +52,7 @@ Get all active alerts and display their fault and title.
 Get-AzsAlert -Filter "Properties/State eq 'Active'"
 ```
 
-Get all active alerts using much more efficient OData filter than getting all alerts from and filtering from example above.
+Get all active alerts using much more efficient OData filter than getting all alerts first and filtering from example above.
 
 Note: This is case sensitive so properties/state for instance will not work
 

--- a/azurestackps-1.4.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
+++ b/azurestackps-1.4.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
@@ -47,6 +47,15 @@ Get-AzsAlert | Where State -EQ 'active' | select FaultTypeId, Title
 
 Get all active alerts and display their fault and title.
 
+### EXAMPLE 3
+```
+Get-AzsAlert -Filter "Properties/State eq 'Active'"
+```
+
+Get all active alerts using much more efficient OData filter than getting all alerts from and filtering from example above.
+
+Note: This is case sensitive so properties/state for instance will not work
+
 ## PARAMETERS
 
 ### -Name

--- a/azurestackps-1.4.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
+++ b/azurestackps-1.4.0/Azs.Infrastructureinsights.Admin/Get-AzsAlert.md
@@ -52,7 +52,7 @@ Get all active alerts and display their fault and title.
 Get-AzsAlert -Filter "Properties/State eq 'Active'"
 ```
 
-Get all active alerts using much more efficient OData filter than getting all alerts from and filtering from example above.
+Get all active alerts using much more efficient OData filter than getting all alerts first and filtering from example above.
 
 Note: This is case sensitive so properties/state for instance will not work
 


### PR DESCRIPTION
When you have a lot of alerts it is much more efficient to use OData rather than getting all alerts and using very slow Where-Object to filter them.

Examples for OData are non-existent on Azure Stack so I created one.

Only the simple filter works for the moment sadly, but for alerts it is good enough.