### PR TITLE
Add Odata filter examples to get-azsippool

### DIFF
--- a/azurestackps-1.3.0/Azs.Fabric.Admin/Get-AzsIpPool.md
+++ b/azurestackps-1.3.0/Azs.Fabric.Admin/Get-AzsIpPool.md
@@ -47,6 +47,15 @@ Get-AzsIpPool -Name "08786a0f-ad8c-43aa-a154-06083abfc1ac"
 
 Get an infrastructure ip pool based on name.
 
+### EXAMPLE 3
+```
+Get-AzsIpPool -Filter "Properties/StartIpAddress eq 'x.x.x.x'"
+```
+
+Get specific IP pool using much more efficient OData filter than getting all pools first and filtering from example above.
+
+Note: This is case sensitive so properties/startipaddress for instance will not work
+
 ## PARAMETERS
 
 ### -Name

--- a/azurestackps-1.4.0/Azs.Fabric.Admin/Get-AzsIpPool.md
+++ b/azurestackps-1.4.0/Azs.Fabric.Admin/Get-AzsIpPool.md
@@ -47,6 +47,15 @@ Get-AzsIpPool -Name "08786a0f-ad8c-43aa-a154-06083abfc1ac"
 
 Get an infrastructure ip pool based on name.
 
+### EXAMPLE 3
+```
+Get-AzsIpPool -Filter "Properties/StartIpAddress eq 'x.x.x.x'"
+```
+
+Get specific IP pool using much more efficient OData filter than getting all pools first and filtering from example above.
+
+Note: This is case sensitive so properties/startipaddress for instance will not work
+
 ## PARAMETERS
 
 ### -Name


### PR DESCRIPTION
Examples for OData are non-existent on Azure Stack so I created one.

It is much more efficient way of filtering than using Where-Object.