### PR TITLE
adding operator and user connect topics to conceptual topics

### DIFF
--- a/docs-conceptual/azurestackps-1.4.0/TOC.yml
+++ b/docs-conceptual/azurestackps-1.4.0/TOC.yml
@@ -1,4 +1,4 @@
-  - name: Azure Stack PowerShell
+- name: Azure Stack PowerShell
   href: overview.md
   items:
   - name: Install
@@ -7,4 +7,3 @@
     href: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-configure-admin
   - name: Connect - User
     href: https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-powershell-configure-user
-

--- a/docs-conceptual/azurestackps-1.4.0/TOC.yml
+++ b/docs-conceptual/azurestackps-1.4.0/TOC.yml
@@ -1,7 +1,10 @@
-- name: Azure Stack PowerShell
+  - name: Azure Stack PowerShell
   href: overview.md
   items:
   - name: Install
     href: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-install?toc=/powershell/azure/azure-stack/toc.json
-  - name: Configure
+  - name: Connect - Cloud Operator
     href: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-configure-admin
+  - name: Connect - User
+    href: https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-powershell-configure-user
+

--- a/docs-conceptual/azurestackps-1.5.0/TOC.yml
+++ b/docs-conceptual/azurestackps-1.5.0/TOC.yml
@@ -3,5 +3,7 @@
   items:
   - name: Install
     href: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-install?toc=/powershell/azure/azure-stack/toc.json
-  - name: Configure
+  - name: Connect - Cloud Operator
     href: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-configure-admin
+  - name: Connect - User
+    href: https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-powershell-configure-user


### PR DESCRIPTION
@bala16 @EdisonDa Hi ... the conceptual topics for the 1.4 and 1.5 need to be updated. David Armour noted some confusion about using the topics a user since the Config (aka 'Connect') topic was for the Operator. I've added the user and operator and retitled them to 'connect'