### PR TITLE
Fixed a positional parameter error from the sample code

### DIFF
--- a/docs-conceptual/azurermps-6.10.0/get-started-azureps.md
+++ b/docs-conceptual/azurermps-6.10.0/get-started-azureps.md
@@ -211,8 +211,7 @@ $vnet = New-AzureRmVirtualNetwork -ResourceGroupName $resourceGroup -Location $l
 
 # Create a public IP address and specify a DNS name
 $publicIp = New-AzureRmPublicIpAddress -ResourceGroupName $resourceGroup -Location $location `
-  -Name "mypublicdns$(Get-Random)" -AllocationMethod Static -IdleTimeoutInMinutes 4
-$publicIp | Select-Object Name,IpAddress
+  -Name "mypublicdns$(Get-Random)" -AllocationMethod Static -IdleTimeoutInMinutes 4 | Select-Object Name,IpAddress
 
 # Create an inbound network security group rule for port 22
 $nsgRuleSSH = New-AzureRmNetworkSecurityRuleConfig -Name myNetworkSecurityGroupRuleSSH  -Protocol Tcp `


### PR DESCRIPTION
Removed $publicIp as a positional parameter from the New-AzureRmPublicIpAddress sample command because it would cause error.