### PR TITLE
Correct 'Connect-AzureRmAccount'

### DIFF
--- a/docs-conceptual/azurermps-6.11.0/install-azurermps-maclinux.md
+++ b/docs-conceptual/azurermps-6.11.0/install-azurermps-maclinux.md
@@ -102,7 +102,7 @@ with your Azure credentials. Importing a module does __not__ require elevated pr
 # Import the module into the PowerShell session
 Import-Module Az
 # Connect to Azure with an interactive dialog for sign-in
-Connect-AzureRmAccount
+Connect-AzAccount
 ```
 
 You'll need to repeat these steps for every new PowerShell session you start. Automatically importing the `Az` module requires


### PR DESCRIPTION
In the context of macOS and Linux, '`Connect-AzureRmAccount` doesn't work and instead it's necessary to use `Connect-AzAccount`. I believe I'm correct in my assumption that this needs changing (based on my own experience), but if not then do please correct me!

Thanks!