### PR TITLE
Changed parameter names as they were mis-spelled

### DIFF
--- a/azurermps-2.3.0/AzureRm.Insights/New-AzureRmAlertRuleEmail.md
+++ b/azurermps-2.3.0/AzureRm.Insights/New-AzureRmAlertRuleEmail.md
@@ -24,21 +24,21 @@ The **New-AzureRmAlertRuleEmail** cmdlet creates an e-mail action for an alert r
 
 ### Example 1: Create an alert rule email action for service owners
 ```
-PS C:\>New-AzureRmAlertRuleEmail -SendToServiceOwners
+PS C:\>New-AzureRmAlertRuleEmail -SendToServiceOwner
 ```
 
 This command creates an alert rule email action to send for its service owners when an alert rule is fired.
 
 ### Example 2: Create an alert rule email action for non-service owners
 ```
-PS C:\>New-AzureRmAlertRuleEmail -CustomEmails pattif@contoso.com,davidchew@contoso.net
+PS C:\>New-AzureRmAlertRuleEmail -CustomEmail pattif@contoso.com,davidchew@contoso.net
 ```
 
 This command creates an alert rule email action for the specified email addresses, but not for the service owners.
 
 ### Example 3: Create an alert rule email action for service owners and non-service owners
 ```
-PS C:\>New-AzureRmAlertRuleEmail -CustomEmails pattif@contoso.net -SendToServiceOwners
+PS C:\>New-AzureRmAlertRuleEmail -CustomEmail pattif@contoso.net -SendToServiceOwner
 ```
 
 This command creates an alert rule email action for the specified address and for its service owners.


### PR DESCRIPTION
There seems to be a spelling mistake in the documentation which has led to us receiving these errors when using the azure rm powershell method - **New-AzureRmAlertRuleEmail**.

A parameter cannot be found that matches parameter name 'SendToServiceOwners'.

and

A parameter cannot be found that matches parameter name 'CustomEmails'.

This PR fixes these parameters in the documentation