### PR TITLE
1387770: Fixed 3 broken links in AzureRmFrontDoor - related files.

### DIFF
--- a/azurermps-6.13.0/AzureRM.FrontDoor/New-AzureRmFrontDoor.md
+++ b/azurermps-6.13.0/AzureRM.FrontDoor/New-AzureRmFrontDoor.md
@@ -254,7 +254,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Set-AzureRmFrontDoor](./Set-AzureRmFrontDoor.md)
 [Remove-AzureRmFrontDoor](./Remove-AzureRmFrontDoor.md)
 [New-AzureRmFrontDoorRoutingRuleObject](./New-AzureRmFrontDoorRoutingRuleObject.md)
-[New-AzureRmFrontDoorHealthProbeSettingObject](./New-AzureRmFrontHealthProbeSettingObject.md)
+[New-AzureRmFrontDoorHealthProbeSettingObject](./New-AzureRmFrontDoorHealthProbeSettingObject.md)
 [New-AzureRmFrontDoorLoadBalancingSettingObject](./New-AzureRmFrontDoorLoadBalancingSettingObject.md)
 [New-AzureRmFrontDoorFrontendEndpointObject](./New-AzureRmFrontDoorFrontendEndpointObject.md)
 [New-AzureRmFrontDoorBackendPoolObject](./New-AzureRmFrontDoorBackendPoolObject.md)

--- a/azurermps-6.13.0/AzureRM.FrontDoor/New-AzureRmFrontDoorManagedRuleObject.md
+++ b/azurermps-6.13.0/AzureRM.FrontDoor/New-AzureRmFrontDoorManagedRuleObject.md
@@ -116,4 +116,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [New-AzureRmFrontDoorFireWallPolicy](./New-AzureRmFrontDoorFireWallPolicy.md)
 [Set-AzureRmFrontDoorFireWallPolicy](./Set-AzureRmFrontDoorFireWallPolicy.md)
-[New-AzureRmFrontDoorRuleGroupOverrideObject](./Set-AzureRmFrontDoorRuleGroupOverrideObject.md)
+[New-AzureRmFrontDoorRuleGroupOverrideObject](./New-AzureRmFrontDoorRuleGroupOverrideObject.md)

--- a/azurermps-6.13.0/AzureRM.FrontDoor/Set-AzureRmFrontDoor.md
+++ b/azurermps-6.13.0/AzureRM.FrontDoor/Set-AzureRmFrontDoor.md
@@ -349,7 +349,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureRmFrontDoor](./Get-AzureRmFrontDoor.md)
 [Remove-AzureRmFrontDoor](./Remove-AzureRmFrontDoor.md)
 [New-AzureRmFrontDoorRoutingRuleObject](./New-AzureRmFrontDoorRoutingRuleObject.md)
-[New-AzureRmFrontDoorHealthProbeSettingObject](./New-AzureRmFrontHealthProbeSettingObject.md)
+[New-AzureRmFrontDoorHealthProbeSettingObject](./New-AzureRmFrontDoorHealthProbeSettingObject.md)
 [New-AzureRmFrontDoorLoadBalancingSettingObject](./New-AzureRmFrontDoorLoadBalancingSettingObject.md)
 [New-AzureRmFrontDoorFrontendEndpointObject](./New-AzureRmFrontDoorFrontendEndpointObject.md)
 [New-AzureRmFrontDoorBackendPoolObject](./New-AzureRmFrontDoorBackendPoolObject.md)


### PR DESCRIPTION
For [Task 1387770: Assist w/ fixing broken links in Azure-docs-pr](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1387770).

In our Azure-docs-pr broken links list, 3 URLs beginning with **https://docs.microsoft.com/azure/...** redirect to files sourced from Azure/azure-docs-powershell, so I'm fixing those links here.