### PR TITLE
Moved the MSI 'must' section first

### DIFF
--- a/docs-conceptual/azurermps-6.13.0/uninstall-azurerm-ps.md
+++ b/docs-conceptual/azurermps-6.13.0/uninstall-azurerm-ps.md
@@ -15,6 +15,19 @@ your system. If you've decided to completely uninstall the Azure PowerShell, giv
 through the [Send-Feedback](/powershell/module/azurerm.profile/send-feedback) cmdlet.
 If you encounter a bug, we'd appreciate it if you [file a GitHub issue](https://github.com/azure/azure-powershell/issues).
 
+
+## Uninstall MSI
+
+If you installed Azure PowerShell using the MSI package, you must uninstall through the Windows
+system rather than PowerShell.
+
+| Platform | Instructions |
+|----------|--------------|
+| Windows 10 | Start > Settings > Apps |
+| Windows 7 </br>Windows 8 | Start > Control Panel > Programs > Uninstall a program |
+
+Once on this screen you should see "Azure PowerShell" in the program listing, and can uninstall from there.
+
 ## Uninstall from PowerShell
 
 If you installed Azure PowerShell using PowerShellGet, you can use the
@@ -115,15 +128,3 @@ script will uninstall all versions of AzureRM __except__ for the latest.
 $versions = (get-installedmodule AzureRM -AllVersions | Select-Object Version)
 $versions[1..($versions.Length-1)]  | foreach { Uninstall-AllModules -TargetModule AzureRM -Version ($_.Version) -Force }
 ```
-
-## Uninstall MSI
-
-If you installed Azure PowerShell using the MSI package, you must uninstall through the Windows
-system rather than PowerShell.
-
-| Platform | Instructions |
-|----------|--------------|
-| Windows 10 | Start > Settings > Apps |
-| Windows 7 </br>Windows 8 | Start > Control Panel > Programs > Uninstall a program |
-
-Once on this screen you should see "Azure PowerShell" in the program listing, and can uninstall from there.


### PR DESCRIPTION
Visual Studio users have the VS installer install Azure Powershell, but generally use Powershell 'raw', and so, as I did - discover too late that they should have tried using the Win 10 Apps uninstall procedure.