### PR TITLE
Update Update-AzRoleManagementPolicy.md

### DIFF
--- a/azps-14.4.0/Az.Resources/Update-AzRoleManagementPolicy.md
+++ b/azps-14.4.0/Az.Resources/Update-AzRoleManagementPolicy.md
@@ -36,7 +36,7 @@ Update a role management policy
 ### Example 1: Update expiration rule of a policy
 ```powershell
 $scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-$expirationRule = [RoleManagementPolicyExpirationRule]@{
+$expirationRule = [Microsoft.Azure.PowerShell.Cmdlets.Resources.Authorization.Models.Api20201001Preview.RoleManagementPolicyExpirationRule]@{
             isExpirationRequired = "false";
             maximumDuration = "P180D";
             id = "Expiration_Admin_Eligibility";
@@ -63,7 +63,7 @@ Each individual `Rule` on a policy can be update independently.
 ### Example 2: Update expiration rule and a notification rule of a policy
 ```powershell
 $scope = "/subscriptions/38ab2ccc-3747-4567-b36b-9478f5602f0d/"
-$expirationRule = [RoleManagementPolicyExpirationRule]@{
+$expirationRule = [Microsoft.Azure.PowerShell.Cmdlets.Resources.Authorization.Models.Api20201001Preview.RoleManagementPolicyExpirationRule]@{
             isExpirationRequired = "false";
             maximumDuration = "P180D";
             id = "Expiration_Admin_Eligibility";
@@ -75,7 +75,7 @@ $expirationRule = [RoleManagementPolicyExpirationRule]@{
             targetInheritableSetting = $null;
             targetEnforcedSetting = $null;
         }
-$notificationRule = [RoleManagementPolicyNotificationRule]@{
+$notificationRule = [Microsoft.Azure.PowerShell.Cmdlets.Resources.Authorization.Models.Api20201001Preview.RoleManagementPolicyNotificationRule]@{
             notificationType = "Email";
             recipientType = "Approver";
             isDefaultRecipientsEnabled = "false";


### PR DESCRIPTION
The current doc examples do not work.

This suggested configuration works.
Tested it my self. Credits to : 
 https://github.com/Azure/azure-powershell/issues/18781#issuecomment-1198247868

This pull request updates the usage of role management policy rule types in the documentation for `Update-AzRoleManagementPolicy`. The main change is to use fully qualified type names in the PowerShell examples to avoid ambiguity and ensure correct type resolution.

**Documentation improvements:**

* Updated the `$expirationRule` variable in both examples to use the fully qualified type name `Microsoft.Azure.PowerShell.Cmdlets.Resources.Authorization.Models.Api20201001Preview.RoleManagementPolicyExpirationRule` instead of the shorthand `RoleManagementPolicyExpirationRule`. [[1]](diffhunk://#diff-356bef11126f330df63c621d1c13cf49d9214a74f9466d4461502ae31df96368L39-R39) [[2]](diffhunk://#diff-356bef11126f330df63c621d1c13cf49d9214a74f9466d4461502ae31df96368L66-R66)
* Updated the `$notificationRule` variable in Example 2 to use the fully qualified type name `Microsoft.Azure.PowerShell.Cmdlets.Resources.Authorization.Models.Api20201001Preview.RoleManagementPolicyNotificationRule` instead of the shorthand `RoleManagementPolicyNotificationRule`.